### PR TITLE
Remove codeowners from super-linter project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
-*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00 @github-actions @GaboFDC @ferrarimarco


### PR DESCRIPTION
Please remove codeowners from super-linter project so they are not listed as owners of this project.